### PR TITLE
Don't restrict level peer dependency version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "cookie-parser": "~1.3.4",
     "express": "~4.12.3",
     "express-session": "~1.11.1",
-    "level": "~0.18.0",
+    "level": "^1.2.0",
     "request": "~2.51.0",
     "rimraf": "~2.3.2",
     "tap": "~0.7.1",
     "tough-cookie": "~0.13.0"
   },
   "peerDependencies": {
-    "level": "~0.18"
+    "level": "*"
   },
   "dependencies": {
     "json-stringify-safe": "~5.0.0"


### PR DESCRIPTION
Older version of level doesn't compile for me, and can't install new one as it breaks level-session-store's peer dependency requirement.
