### PR TITLE
Add real error message to require('level') failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(session) {
     try {
       var level = require('level');
     } catch (err) {
-      throw new Error('If you are not passing in an existing level instance, you must have the package level installed');
+      throw new Error('If you are not passing in an existing level instance, you must have the package level installed. ' + err.message);
     }
 
     this.db = level(name, opts, function(err, db) {


### PR DESCRIPTION
`level` can be installed but won't require correctly due to broken native build e.g. "invalid ELF header". The current error message masks the real problem.
