### PR TITLE
Init the `length` key when you provide your own level instance too

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function (session) {
       this._createDB(db, opts)
     } else {
       this.mungeKey = true
+      this._initLength(db)
       this.db = db
     }
   }
@@ -37,13 +38,18 @@ module.exports = function (session) {
         throw err
       }
 
-      var key = self.getKey(lengthKey)
-      db.get(key, function (err, length) {
-        if (err && err.type !== 'NotFoundError') return self.emit('error', err)
-        length = parseInt(length, 10) || 0
-        db.put(key, length)
-        self.emit('connect')
-      })
+      self._initLength(db)
+    })
+  }
+
+  LevelSessionStore.prototype._initLength = function (db) {
+    var self = this
+    var key = self.getKey(lengthKey)
+    db.get(key, function (err, length) {
+      if (err && err.type !== 'NotFoundError') return self.emit('error', err)
+      length = parseInt(length, 10) || 0
+      db.put(key, length)
+      self.emit('connect')
     })
   }
 

--- a/test.js
+++ b/test.js
@@ -10,7 +10,8 @@ var cookieParser = require('cookie-parser')
 var Store = require('./')(session)
 
 var app = express()
-var store = new Store(path.join(os.tmpdir(), 'level-session-store'))
+var level = require('level')(path.join(os.tmpdir(), 'level-session-store'))
+var store = new Store(level)
 var noPermPath = path.join(os.tmpdir(), 'noperms')
 var mw = session({
   store: store,


### PR DESCRIPTION
Hiya

When I provide my own leveldb instance, I get `NotFoundError: Key not found in database [_session/__length__]` errors. 

This is probably not a smart way to fix it; prototype confuses me easily. But it shows what I mean. 

Wasn't sure if I should copy/paste the whole test suite to test both ways of using level. Let me know and I'll update the PR?